### PR TITLE
Fix box intersection logic

### DIFF
--- a/chebai/models/box_eval.py
+++ b/chebai/models/box_eval.py
@@ -2,6 +2,7 @@ import numpy as np
 
 n = len(boxes)
 containment_matrix = np.zeros((n, n), dtype=bool)
+threshold = 0.99
 
 for i in range(n):
     for j in range(n):
@@ -9,27 +10,19 @@ for i in range(n):
             box1 = boxes[i]
             box2 = boxes[j]
 
-            min_corners_box_1 = np.minimum(box1[0], box1[1])
-            max_corners_box_1 = np.maximum(box1[0], box1[1])
+            min_corners_box_1 = np.min(box1, axis=-2)
+            max_corners_box_1 = np.max(box1, axis=-2)
 
-            min_corners_box_2 = np.minimum(box2[0], box2[1])
-            max_corners_box_2 = np.maximum(box2[0], box2[1])
+            vol_box_1 = np.prod(max_corners_box_1 - min_corners_box_1)
 
-            dim = len(min_corners_box_1)
+            min_corners_box_2 = np.min(box2, axis=-2)
+            max_corners_box_2 = np.max(box2, axis=-2)
 
-            membership_per_dim = []
-            for d in range(dim):
-                  a = max(min_corners_box_1[d], min_corners_box_2[d])
-                  b = min(max_corners_box_1[d], max_corners_box_2[d])
-                  intersection = (a <= b) * (b - a)
-                  size_of_a = min_corners_box_1[d] + max_corners_box_1[d]
+            a = np.maximum(min_corners_box_1, min_corners_box_2) # right face of intersection
+            b = np.minimum(max_corners_box_1, max_corners_box_2) # left face of intersection
 
-                  # if box_1 is not contained in box_2, then is_contained is zero
+            intersection_per_dim = (a <= b) * (b - a)
+            vol_intersection = np.prod(intersection_per_dim)
+            box_1_is_contained_in_box_2 = vol_intersection / vol_box_1
 
-                  is_contained = abs(intersection / size_of_a)
-                  membership_per_dim.append(1 if is_contained else 0)
-
-
-            count = sum(1 for item in membership_per_dim if item == 1)
-            box_1_is_contained_in_box_2 = (count == 10)
-            containment_matrix[i][j] = box_1_is_contained_in_box_2
+            containment_matrix[i][j] = box_1_is_contained_in_box_2 > threshold


### PR DESCRIPTION
The results seemed incorrect for my test case `boxes = np.array([[[1,1],[4,4]],[[1,1],[2,2]],[[2,2],[3,3]],[[2.5,2.5],[3.5,3.5]]])`, so I went ahead and fixed it. It implements a containment check between boxes: B is a considered a sub-box of A iff the conditional probability P(A|B)=P(A and B)/P(B) > 0.99