### PR TITLE
Refactor Chebi Term Callback

### DIFF
--- a/chebai/preprocessing/datasets/chebi.py
+++ b/chebai/preprocessing/datasets/chebi.py
@@ -258,7 +258,16 @@ class _ChEBIDataExtractor(_DynamicDataset, ABC):
         g = nx.DiGraph()
         for n in elements:
             g.add_node(n["id"], **n)
-        g.add_edges_from([(p, q["id"]) for q in elements for p in q["parents"]])
+
+        # Only take the edges which connects the existing nodes, to avoid internal creation of obsolete nodes
+        g.add_edges_from(
+            [
+                (p, q["id"])
+                for q in elements
+                for p in q["parents"]
+                if g.has_node(p) and g.has_node(q["id"])
+            ]
+        )
 
         print("Compute transitive closure")
         return nx.transitive_closure_dag(g)

--- a/chebai/preprocessing/datasets/chebi.py
+++ b/chebai/preprocessing/datasets/chebi.py
@@ -260,13 +260,9 @@ class _ChEBIDataExtractor(_DynamicDataset, ABC):
             g.add_node(n["id"], **n)
 
         # Only take the edges which connects the existing nodes, to avoid internal creation of obsolete nodes
+        # https://github.com/ChEB-AI/python-chebai/pull/55#issuecomment-2386654142
         g.add_edges_from(
-            [
-                (p, q["id"])
-                for q in elements
-                for p in q["parents"]
-                if g.has_node(p) and g.has_node(q["id"])
-            ]
+            [(p, q["id"]) for q in elements for p in q["parents"] if g.has_node(p)]
         )
 
         print("Compute transitive closure")


### PR DESCRIPTION
- ### Issue #49

---


**Note:** The `term_callback` is used in two places:
1. The `_extract_class_hierarchy` method in `_ChEBIDataExtractor`.
2. The `_extract_class_hierarchy` method in `ChEBIOverXPartial`.

In this PR, we have updated the code in the `_extract_class_hierarchy` method of `_ChEBIDataExtractor` to reflect the new `term_callback` implementation. The corresponding method in `ChEBIOverXPartial` will be updated in **PR #54** to call the `_extract_class_hierarchy` method in `_ChEBIDataExtractor`, ensuring consistency.

**Dependency Note**: Kindly note that this PR should be merged **after PR #54**.