### PR TITLE
compatibility with chebai-graph and unifying the 3-level data handling

### DIFF
--- a/chebai/loss/bce_weighted.py
+++ b/chebai/loss/bce_weighted.py
@@ -43,8 +43,10 @@ class BCEWeighted(torch.nn.BCEWithLogitsLoss):
             self.beta is not None
             and self.data_extractor is not None
             and all(
-                os.path.exists(os.path.join(self.data_extractor.raw_dir, raw_file))
-                for raw_file in self.data_extractor.raw_file_names
+                os.path.exists(
+                    os.path.join(self.data_extractor.processed_dir_main, file_name)
+                )
+                for file_name in self.data_extractor.processed_main_file_names
             )
             and self.pos_weight is None
         ):
@@ -53,13 +55,13 @@ class BCEWeighted(torch.nn.BCEWithLogitsLoss):
                     pd.read_pickle(
                         open(
                             os.path.join(
-                                self.data_extractor.raw_dir,
-                                raw_file_name,
+                                self.data_extractor.processed_dir_main,
+                                file_name,
                             ),
                             "rb",
                         )
                     )
-                    for raw_file_name in self.data_extractor.raw_file_names
+                    for file_name in self.data_extractor.processed_main_file_names
                 ]
             )
             value_counts = []

--- a/chebai/preprocessing/datasets/base.py
+++ b/chebai/preprocessing/datasets/base.py
@@ -135,9 +135,14 @@ class XYBaseDataModule(LightningDataModule):
         return os.path.join("data", self._name)
 
     @property
+    def processed_dir_main(self) -> str:
+        """Name of the directory where processed (but not tokenized) data is stored."""
+        return os.path.join(self.base_dir, "processed")
+
+    @property
     def processed_dir(self) -> str:
-        """Name of the directory where the processed data is stored."""
-        return os.path.join(self.base_dir, "processed", *self.identifier)
+        """Name of the directory where the processed and tokenized data is stored."""
+        return os.path.join(self.processed_dir_main, *self.identifier)
 
     @property
     def raw_dir(self) -> str:
@@ -1131,19 +1136,6 @@ class _DynamicDataset(XYBaseDataModule, ABC):
             self.base_dir,
             self._name,
             "processed",
-        )
-
-    @property
-    def processed_dir(self) -> str:
-        """
-        Returns the specific directory path for processed data, including identifiers.
-
-        Returns:
-            str: The path to the processed data directory, including additional identifiers.
-        """
-        return os.path.join(
-            self.processed_dir_main,
-            *self.identifier,
         )
 
     @property

--- a/chebai/preprocessing/datasets/base.py
+++ b/chebai/preprocessing/datasets/base.py
@@ -394,7 +394,7 @@ class XYBaseDataModule(LightningDataModule):
         raise NotImplementedError
 
     @property
-    def processed_dir_main_file_names_dict(self) -> dict:
+    def processed_main_file_names_dict(self) -> dict:
         """
         Returns a dictionary mapping processed data file names.
 
@@ -405,14 +405,14 @@ class XYBaseDataModule(LightningDataModule):
         raise NotImplementedError
 
     @property
-    def processed_dir_main_file_names(self) -> List[str]:
+    def processed_main_file_names(self) -> List[str]:
         """
         Returns a list of file names for processed data (before tokenization).
 
         Returns:
             List[str]: A list of file names corresponding to the processed data.
         """
-        return list(self.processed_dir_main_file_names_dict.values())
+        return list(self.processed_main_file_names_dict.values())
 
     @property
     def processed_file_names_dict(self) -> dict:
@@ -721,7 +721,7 @@ class _DynamicDataset(XYBaseDataModule, ABC):
         """
         print("Checking for processed data in", self.processed_dir_main)
 
-        processed_name = self.processed_dir_main_file_names_dict["data"]
+        processed_name = self.processed_main_file_names_dict["data"]
         if not os.path.isfile(os.path.join(self.processed_dir_main, processed_name)):
             print("Missing processed data file (`data.pkl` file)")
             os.makedirs(self.processed_dir_main, exist_ok=True)
@@ -812,7 +812,7 @@ class _DynamicDataset(XYBaseDataModule, ABC):
             self._load_data_from_file(
                 os.path.join(
                     self.processed_dir_main,
-                    self.processed_dir_main_file_names_dict["data"],
+                    self.processed_main_file_names_dict["data"],
                 )
             ),
             os.path.join(self.processed_dir, self.processed_file_names_dict["data"]),
@@ -1147,7 +1147,7 @@ class _DynamicDataset(XYBaseDataModule, ABC):
         )
 
     @property
-    def processed_dir_main_file_names_dict(self) -> dict:
+    def processed_main_file_names_dict(self) -> dict:
         """
         Returns a dictionary mapping processed data file names.
 

--- a/chebai/preprocessing/datasets/base.py
+++ b/chebai/preprocessing/datasets/base.py
@@ -394,45 +394,61 @@ class XYBaseDataModule(LightningDataModule):
         raise NotImplementedError
 
     @property
-    def processed_file_names(self) -> List[str]:
+    def processed_dir_main_file_names_dict(self) -> dict:
         """
-        Returns the list of processed file names.
-
-        This property should be implemented by subclasses to provide the list of processed file names.
+        Returns a dictionary mapping processed data file names.
 
         Returns:
-            List[str]: The list of processed file names.
+            dict: A dictionary mapping dataset key to their respective file names.
+                  For example, {"data": "data.pkl"}.
         """
         raise NotImplementedError
+
+    @property
+    def processed_dir_main_file_names(self) -> List[str]:
+        """
+        Returns a list of file names for processed data (before tokenization).
+
+        Returns:
+            List[str]: A list of file names corresponding to the processed data.
+        """
+        return list(self.processed_dir_main_file_names_dict.values())
+
+    @property
+    def processed_file_names_dict(self) -> dict:
+        """
+        Returns a dictionary for the processed and tokenized data files.
+
+        Returns:
+            dict: A dictionary mapping dataset keys to their respective file names.
+                  For example, {"data": "data.pt"}.
+        """
+        raise NotImplementedError
+
+    @property
+    def processed_file_names(self) -> List[str]:
+        """
+        Returns a list of file names for processed data.
+
+        Returns:
+            List[str]: A list of file names corresponding to the processed data.
+        """
+        return list(self.processed_file_names_dict.values())
 
     @property
     def raw_file_names(self) -> List[str]:
         """
         Returns the list of raw file names.
 
-        This property should be implemented by subclasses to provide the list of raw file names.
-
         Returns:
             List[str]: The list of raw file names.
         """
-        raise NotImplementedError
-
-    @property
-    def processed_file_names_dict(self) -> dict:
-        """
-        Returns the dictionary of processed file names.
-
-        This property should be implemented by subclasses to provide the dictionary of processed file names.
-
-        Returns:
-            dict: The dictionary of processed file names.
-        """
-        raise NotImplementedError
+        return list(self.raw_file_names_dict.values())
 
     @property
     def raw_file_names_dict(self) -> dict:
         """
-        Returns the dictionary of raw file names.
+        Returns the dictionary of raw file names (i.e., files that are directly obtained from an external source).
 
         This property should be implemented by subclasses to provide the dictionary of raw file names.
 
@@ -1133,10 +1149,10 @@ class _DynamicDataset(XYBaseDataModule, ABC):
     @property
     def processed_dir_main_file_names_dict(self) -> dict:
         """
-        Returns a dictionary mapping processed data file names, processed by `prepare_data` method.
+        Returns a dictionary mapping processed data file names.
 
         Returns:
-            dict: A dictionary mapping dataset types to their respective processed file names.
+            dict: A dictionary mapping dataset key to their respective file names.
                   For example, {"data": "data.pkl"}.
         """
         return {"data": "data.pkl"}
@@ -1144,21 +1160,10 @@ class _DynamicDataset(XYBaseDataModule, ABC):
     @property
     def processed_file_names_dict(self) -> dict:
         """
-        Returns a dictionary mapping processed and transformed data file names to their final formats, which are
-        processed by `setup` method.
+        Returns a dictionary for the processed and tokenized data files.
 
         Returns:
-            dict: A dictionary mapping dataset types to their respective final file names.
+            dict: A dictionary mapping dataset keys to their respective file names.
                   For example, {"data": "data.pt"}.
         """
         return {"data": "data.pt"}
-
-    @property
-    def processed_file_names(self) -> List[str]:
-        """
-        Returns a list of file names for processed data.
-
-        Returns:
-            List[str]: A list of file names corresponding to the processed data.
-        """
-        return list(self.processed_file_names_dict.values())

--- a/chebai/preprocessing/datasets/chebi.py
+++ b/chebai/preprocessing/datasets/chebi.py
@@ -216,9 +216,7 @@ class _ChEBIDataExtractor(_DynamicDataset, ABC):
         Returns:
             str: The file path of the loaded ChEBI ontology.
         """
-        chebi_name = (
-            f"chebi.obo" if version == self.chebi_version else f"chebi_v{version}.obo"
-        )
+        chebi_name = self.raw_file_names_dict["chebi"]
         chebi_path = os.path.join(self.raw_dir, chebi_name)
         if not os.path.isfile(chebi_path):
             print(
@@ -539,6 +537,10 @@ class _ChEBIDataExtractor(_DynamicDataset, ABC):
             return res
         else:
             return os.path.join(res, f"single_{self.single_class}")
+
+    @property
+    def raw_file_names_dict(self) -> dict:
+        return {"chebi": "chebi.obo"}
 
 
 class JCIExtendedBase(_ChEBIDataExtractor):

--- a/chebai/preprocessing/datasets/chebi.py
+++ b/chebai/preprocessing/datasets/chebi.py
@@ -185,7 +185,7 @@ class _ChEBIDataExtractor(_DynamicDataset, ABC):
             if not os.path.isfile(
                 os.path.join(
                     self._chebi_version_train_obj.processed_dir_main,
-                    self._chebi_version_train_obj.processed_dir_main_file_names_dict[
+                    self._chebi_version_train_obj.processed_main_file_names_dict[
                         "data"
                     ],
                 )

--- a/chebai/preprocessing/datasets/protein_pretraining.py
+++ b/chebai/preprocessing/datasets/protein_pretraining.py
@@ -64,7 +64,7 @@ class _ProteinPretrainingData(_DynamicDataset, ABC):
             *args: Additional positional arguments.
             **kwargs: Additional keyword arguments.
         """
-        processed_name = self.processed_dir_main_file_names_dict["data"]
+        processed_name = self.processed_main_file_names_dict["data"]
         if not os.path.isfile(os.path.join(self.processed_dir_main, processed_name)):
             print("Missing processed data file (`data.pkl` file)")
             os.makedirs(self.processed_dir_main, exist_ok=True)

--- a/chebai/result/utils.py
+++ b/chebai/result/utils.py
@@ -66,6 +66,13 @@ def _run_batch(batch, model, collate):
     return preds, labels
 
 
+def _concat_tuple(l):
+    if isinstance(l[0], tuple):
+        print(l[0])
+        return tuple([torch.cat([t[i] for t in l]) for i in range(len(l[0]))])
+    return torch.cat(l)
+
+
 def evaluate_model(
     model: ChebaiBaseNet,
     data_module: XYBaseDataModule,
@@ -125,12 +132,12 @@ def evaluate_model(
             if buffer_dir is not None:
                 if n_saved * batch_size >= save_batch_size:
                     torch.save(
-                        torch.cat(preds_list),
+                        _concat_tuple(preds_list),
                         os.path.join(buffer_dir, f"preds{save_ind:03d}.pt"),
                     )
                     if labels_list[0] is not None:
                         torch.save(
-                            torch.cat(labels_list),
+                            _concat_tuple(labels_list),
                             os.path.join(buffer_dir, f"labels{save_ind:03d}.pt"),
                         )
                     preds_list = []
@@ -141,20 +148,20 @@ def evaluate_model(
         n_saved += 1
 
     if buffer_dir is None:
-        test_preds = torch.cat(preds_list)
+        test_preds = _concat_tuple(preds_list)
         if labels_list is not None:
-            test_labels = torch.cat(labels_list)
+            test_labels = _concat_tuple(labels_list)
 
             return test_preds, test_labels
         return test_preds, None
     else:
         torch.save(
-            torch.cat(preds_list),
+            _concat_tuple(preds_list),
             os.path.join(buffer_dir, f"preds{save_ind:03d}.pt"),
         )
         if labels_list[0] is not None:
             torch.save(
-                torch.cat(labels_list),
+                _concat_tuple(labels_list),
                 os.path.join(buffer_dir, f"labels{save_ind:03d}.pt"),
             )
 


### PR DESCRIPTION
This PR introduces two changes needed to keep chebai-graph running:
- `evaluate_model` can handle tensor-tuples as predictions and labels (instead of tensors). This is needed for GNN pretraining where atom and bond properties are predicted separately.
- The `processed_dir_main` was only included for specific subclasses, but processing of atom / bond properties requires access to the data files on a general level. Now, all directories and file lists are defined in the `XYBaseDataModule`. This also resolves #59 (ChEBI now has raw data, the BCEWeighted uses the correct data file)