### PR TITLE
load processed data correctly when retrieving splits from csv

### DIFF
--- a/chebai/preprocessing/datasets/base.py
+++ b/chebai/preprocessing/datasets/base.py
@@ -1045,9 +1045,7 @@ class _DynamicDataset(XYBaseDataModule, ABC):
         splits_df = pd.read_csv(self.splits_file_path)
 
         filename = self.processed_file_names_dict["data"]
-        data = torch.load(
-            os.path.join(self.processed_dir, filename), weights_only=False
-        )
+        data = self.load_processed_data(filename=filename)
         df_data = pd.DataFrame(data)
 
         train_ids = splits_df[splits_df["split"] == "train"]["id"]


### PR DESCRIPTION
Currently, the data is loaded directly when retrieving splits from csv. However, it should use the `load_processed_data` function. This ensures that child classes with a more complex loading system (e.g. for GNNs) load their data correctly.