### PR TITLE
add new lightning / python versions to setup / tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     author_email="martin.glauer@ovgu.de",
     description="",
     zip_safe=False,
-    python_requires=">=3.9, <3.12",
+    python_requires=">=3.9, <3.13",
     install_requires=[
         "certifi",
         "idna",

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "matplotlib",
         "rdkit",
         "selfies",
-        "lightning<=2.1",
+        "lightning<=2.1,>=2.5",
         "jsonargparse[signatures]>=4.17",
         "omegaconf",
         "seaborn",

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "matplotlib",
         "rdkit",
         "selfies",
-        "lightning<=2.1,>=2.5",
+        "lightning>=2.5",
         "jsonargparse[signatures]>=4.17",
         "omegaconf",
         "seaborn",


### PR DESCRIPTION
Due to new versions, the latest python 3.12 version (3.12.8) and lightning version (2.5) are now working with chebai. However, python 3.13 raises some new error (see #66 ). 

solves #43 