### PR TITLE
remove argument links to criterion

### DIFF
--- a/chebai/cli.py
+++ b/chebai/cli.py
@@ -47,13 +47,6 @@ class ChebaiCLI(LightningCLI):
         parser.link_arguments(
             "model.init_args.out_dim", "trainer.callbacks.init_args.num_labels"
         )
-        parser.link_arguments(
-            "data", "model.init_args.criterion.init_args.data_extractor"
-        )
-        parser.link_arguments(
-            "data.init_args.chebi_version",
-            "model.init_args.criterion.init_args.data_extractor.init_args.chebi_version",
-        )
 
     @staticmethod
     def subcommands() -> Dict[str, Set[str]]:


### PR DESCRIPTION
In #69, I added links between `chebi_version` arguments. This way, you only need to type in the chebi version once and avoid the potential for e.g. the semantic loss checking for inconsistencies in version 200, while the training data is from version 231.

However, this leads to issues when someone is using a different loss function than `BCEWeighted`. Then, the link leads to an argument of the loss function that does not exist, causing an error in `jsonargparse` (the error is shown as an `IndexError`, but that is the error it raises while trying to generate an error message, not the actual error).

For now, I removed the argument linking.