### PR TITLE
base BCE weighted on tokenized data

### DIFF
--- a/chebai/loss/bce_weighted.py
+++ b/chebai/loss/bce_weighted.py
@@ -50,32 +50,25 @@ class BCEWeighted(torch.nn.BCEWithLogitsLoss):
             and self.data_extractor is not None
             and all(
                 os.path.exists(
-                    os.path.join(self.data_extractor.processed_dir_main, file_name)
+                    os.path.join(self.data_extractor.processed_dir, file_name)
                 )
-                for file_name in self.data_extractor.processed_main_file_names
+                for file_name in self.data_extractor.processed_file_names
             )
             and self.pos_weight is None
         ):
             print(
                 f"Computing loss-weights based on v{self.data_extractor.chebi_version} dataset (beta={self.beta})"
             )
-            complete_data = pd.concat(
+            complete_labels = torch.concat(
                 [
-                    pd.read_pickle(
-                        open(
-                            os.path.join(
-                                self.data_extractor.processed_dir_main,
-                                file_name,
-                            ),
-                            "rb",
-                        )
-                    )
-                    for file_name in self.data_extractor.processed_main_file_names
+                    torch.stack([
+                        torch.Tensor(row["labels"]) for row in
+                        self.data_extractor.load_processed_data(filename=file_name)
+                    ])
+                    for file_name in self.data_extractor.processed_file_names
                 ]
             )
-            value_counts = []
-            for c in complete_data.columns[3:]:
-                value_counts.append(len([v for v in complete_data[c] if v]))
+            value_counts = complete_labels.sum(dim=0)
             weights = [
                 (1 - self.beta) / (1 - pow(self.beta, value)) for value in value_counts
             ]

--- a/chebai/loss/bce_weighted.py
+++ b/chebai/loss/bce_weighted.py
@@ -61,10 +61,14 @@ class BCEWeighted(torch.nn.BCEWithLogitsLoss):
             )
             complete_labels = torch.concat(
                 [
-                    torch.stack([
-                        torch.Tensor(row["labels"]) for row in
-                        self.data_extractor.load_processed_data(filename=file_name)
-                    ])
+                    torch.stack(
+                        [
+                            torch.Tensor(row["labels"])
+                            for row in self.data_extractor.load_processed_data(
+                                filename=file_name
+                            )
+                        ]
+                    )
                     for file_name in self.data_extractor.processed_file_names
                 ]
             )

--- a/chebai/result/classification.py
+++ b/chebai/result/classification.py
@@ -78,7 +78,7 @@ def print_metrics(
     print(f"Micro-Recall: {recall_micro(preds, labels):3f}")
     if markdown_output:
         print(
-            f"| Model | Macro-F1 | Micro-F1 | Macro-Precision | Micro-Precision | Macro-Recall | Micro-Recall | Balanced Accuracy"
+            f"| Model | Macro-F1 | Micro-F1 | Macro-Precision | Micro-Precision | Macro-Recall | Micro-Recall | Balanced Accuracy |"
         )
         print(f"| --- | --- | --- | --- | --- | --- | --- | --- |")
         print(

--- a/chebai/result/utils.py
+++ b/chebai/result/utils.py
@@ -156,11 +156,12 @@ def evaluate_model(
             return test_preds, test_labels
         return test_preds, None
     elif len(preds_list) < 0:
-        torch.save(
-            _concat_tuple(preds_list),
-            os.path.join(buffer_dir, f"preds{save_ind:03d}.pt"),
-        )
-        if labels_list[0] is not None:
+        if len(preds_list) > 0 and preds_list[0] is not None:
+            torch.save(
+                _concat_tuple(preds_list),
+                os.path.join(buffer_dir, f"preds{save_ind:03d}.pt"),
+            )
+        if len(labels_list) > 0 and labels_list[0] is not None:
             torch.save(
                 _concat_tuple(labels_list),
                 os.path.join(buffer_dir, f"labels{save_ind:03d}.pt"),


### PR DESCRIPTION
Previously, the class-based weighting used the pkl-files from processed-main (untokenized). This has two disadvantages:
1. If some instances get thrown out due to not being tokenizable, the weighting will be a bit off
2. If a user wants to provide their own tokenized datasets, they don't have to change the untokenized one as well

I also added a safeguard to avoid concatenating empty prediction lists which would raise an error.