### PR TITLE
Add `n_token_limit` to dataset

### DIFF
--- a/chebai/preprocessing/datasets/base.py
+++ b/chebai/preprocessing/datasets/base.py
@@ -314,8 +314,13 @@ class XYBaseDataModule(LightningDataModule):
             if d["features"] is not None
         ]
         # filter for missing features in resulting data, keep features length below token limit
-        data = [val for val in data if val["features"] is not None
-                and self.n_token_limit is None or len(val["features"]) <= self.n_token_limit]
+        data = [
+            val
+            for val in data
+            if val["features"] is not None
+            and self.n_token_limit is None
+            or len(val["features"]) <= self.n_token_limit
+        ]
 
         return data
 

--- a/chebai/preprocessing/datasets/base.py
+++ b/chebai/preprocessing/datasets/base.py
@@ -79,6 +79,7 @@ class XYBaseDataModule(LightningDataModule):
         inner_k_folds: int = -1,  # use inner cross-validation if > 1
         fold_index: Optional[int] = None,
         base_dir: Optional[str] = None,
+        n_token_limit: Optional[int] = None,
         **kwargs,
     ):
         super().__init__()
@@ -110,6 +111,7 @@ class XYBaseDataModule(LightningDataModule):
             ), "fold_index can't be larger than the total number of folds"
         self.fold_index = fold_index
         self._base_dir = base_dir
+        self.n_token_limit = n_token_limit
         os.makedirs(self.raw_dir, exist_ok=True)
         os.makedirs(self.processed_dir, exist_ok=True)
         if self.use_inner_cross_validation:
@@ -311,8 +313,9 @@ class XYBaseDataModule(LightningDataModule):
             for d in tqdm.tqdm(self._load_dict(path), total=lines)
             if d["features"] is not None
         ]
-        # filter for missing features in resulting data
-        data = [val for val in data if val["features"] is not None]
+        # filter for missing features in resulting data, keep features length below token limit
+        data = [val for val in data if val["features"] is not None
+                and self.n_token_limit is None or len(val["features"]) <= self.n_token_limit]
 
         return data
 
@@ -1181,4 +1184,6 @@ class _DynamicDataset(XYBaseDataModule, ABC):
             dict: A dictionary mapping dataset keys to their respective file names.
                   For example, {"data": "data.pt"}.
         """
+        if self.n_token_limit is not None:
+            return {"data": f"data_maxlen{self.n_token_limit}.pt"}
         return {"data": "data.pt"}


### PR DESCRIPTION
I added a new parameter to the base dataset. If this parameter is set, after tokenisation, all instances in the dataset will be removed that have more than `n_token_limit` tokens. This allows to train models with `max_position_embeddings=n_token_limit+1`. For instance, in ChEBI, 99% of instances have less than 300 SMILES tokens. Using that as a limit allows to reduce the `max_position_embeddings` from 1800 (current default) to 301. This is useful for training runs as it allows as higher batch size and efficient memory usage. For "production models", I would recommend a higher number (e.g. 600 or 900)