### PR TITLE
fix order of operations during none filtering in data preprocessing

### DIFF
--- a/chebai/preprocessing/datasets/base.py
+++ b/chebai/preprocessing/datasets/base.py
@@ -335,8 +335,9 @@ class XYBaseDataModule(LightningDataModule):
             val
             for val in data
             if val["features"] is not None
-            and self.n_token_limit is None
-            or len(val["features"]) <= self.n_token_limit
+            and (
+                self.n_token_limit is None or len(val["features"]) <= self.n_token_limit
+            )
         ]
 
         return data


### PR DESCRIPTION
solves https://github.com/ChEB-AI/python-chebai-graph/issues/5

Due to missing brackets, it was checked if `val["features"]` is None **or** if it has a certain length. It should be: **only if** `val["features"]` is not None, check for the length.

@aditya0by0 can you check if that resolves your issue?

Also: For graph neural network, we should probably count the number of nodes towards the `n_token_limit`