### PR TITLE
Improve setup override logic for processed property handling in GraphRepository

### DIFF
--- a/chebai/preprocessing/datasets/base.py
+++ b/chebai/preprocessing/datasets/base.py
@@ -440,13 +440,25 @@ class XYBaseDataModule(LightningDataModule):
         ):
             self.setup_processed()
 
-        if not ("keep_reader" in kwargs and kwargs["keep_reader"]):
-            self.reader.on_finish()
+        self._after_setup(**kwargs)
 
+    def _after_setup(self, **kwargs):
+        """
+        Finalize the setup process after ensuring the processed data is available.
+
+        This method performs post-setup tasks like finalizing the reader and setting internal properties.
+        """
+        self.reader.on_finish()
         self._set_processed_data_props()
 
     def _set_processed_data_props(self):
+        """
+        Load processed data and extract metadata.
 
+        Sets:
+            - self._num_of_labels: Number of target labels in the dataset.
+            - self._feature_vector_size: Maximum feature vector length across all data points.
+        """
         data_pt = torch.load(
             os.path.join(self.processed_dir, self.processed_file_names_dict["data"]),
             weights_only=False,


### PR DESCRIPTION

Currently, in the `GraphRepository`, the `setup` method is overridden to call `_setup_properties()` after the processed data is available:

```python
def setup(self, **kwargs):
    super().setup(keep_reader=True, **kwargs)
    self._setup_properties()

    self.reader.on_finish()
```

This override introduces a couple of issues:

1. **Bypassing the setup flag**:
   The base class uses `_setup_data_flag` to prevent multiple invocations of the `setup()` method:

   ```python
   def setup(self, *args, **kwargs) -> None:
       if self._setup_data_flag != 1:
           return
       self._setup_data_flag += 1
       ...
   ```

   Overriding `setup()` in the derived class causes this mechanism to be bypassed or duplicated unintentionally.

2. **Manual control over reader finalization**:
   To prevent `reader.on_finish()` from executing before `_setup_properties()` is complete, the derived class needs to manually pass `keep_reader=True` to the base `setup()` method. This adds unnecessary complexity and tight coupling between the base and derived classes.

---

### ✅ **Proposed Solution: Introduce `_after_setup()` hook in the base class**

To resolve these issues cleanly, introduce an `_after_setup(**kwargs)` method in the base class. This hook would be called after data preprocessing and flag updates are completed:

**Base class:**

```python
def setup(self, *args, **kwargs) -> None:
    if self._setup_data_flag != 1:
        return

    self._setup_data_flag += 1
    ...
    self._after_setup(**kwargs)

def _after_setup(self, **kwargs):
    self.reader.on_finish()
    self._set_processed_data_props()
```

**GraphRepository subclass:**

```python
def _after_setup(self, **kwargs):
    self._setup_properties()
    super()._after_setup(**kwargs)
```

This change enables:

* Cleaner and safer extension of the setup process.
* Proper use of the base class flag mechanism.
* Decoupling of reader finalization from the timing of `_setup_properties()`.


