### PR TITLE
Fix: Use __name__ instead of custom NAME attribute for class registration

### DIFF
--- a/chebai/models/base.py
+++ b/chebai/models/base.py
@@ -26,11 +26,7 @@ class ChebaiBaseNet(LightningModule, ABC):
         optimizer_kwargs (Dict[str, Any], optional): Additional keyword arguments for the optimizer. Defaults to None.
         **kwargs: Additional keyword arguments.
 
-    Attributes:
-        NAME (str): The name of the model.
     """
-
-    NAME = None
 
     def __init__(
         self,

--- a/chebai/models/base.py
+++ b/chebai/models/base.py
@@ -88,10 +88,10 @@ class ChebaiBaseNet(LightningModule, ABC):
         Args:
             **kwargs: Additional keyword arguments.
         """
-        if cls.NAME in _MODEL_REGISTRY:
-            raise ValueError(f"Model {cls.NAME} does already exist")
+        if cls.__name__ in _MODEL_REGISTRY:
+            raise ValueError(f"Model {cls.__name__} does already exist")
         else:
-            _MODEL_REGISTRY[cls.NAME] = cls
+            _MODEL_REGISTRY[cls.__name__] = cls
 
     def _get_prediction_and_labels(
         self, data: Dict[str, Any], labels: torch.Tensor, output: torch.Tensor

--- a/chebai/models/chemberta.py
+++ b/chebai/models/chemberta.py
@@ -20,8 +20,6 @@ MAX_LEN = 1800
 
 
 class ChembertaPre(ChebaiBaseNet):
-    NAME = "ChembertaPre"
-
     def __init__(self, p=0.2, **kwargs):
         super().__init__(**kwargs)
         self._p = p
@@ -47,8 +45,6 @@ class ChembertaPre(ChebaiBaseNet):
 
 
 class Chemberta(ChebaiBaseNet):
-    NAME = "Chemberta"
-
     def __init__(self, **kwargs):
         # Remove this property in order to prevent it from being stored as a
         # hyper parameter

--- a/chebai/models/chemyk.py
+++ b/chebai/models/chemyk.py
@@ -15,8 +15,6 @@ logging.getLogger("pysmiles").setLevel(logging.CRITICAL)
 
 
 class ChemYK(ChebaiBaseNet):
-    NAME = "ChemYK"
-
     def __init__(self, in_d, out_d, num_classes, **kwargs):
         super().__init__(num_classes, **kwargs)
         d_internal = in_d

--- a/chebai/models/electra.py
+++ b/chebai/models/electra.py
@@ -31,15 +31,12 @@ class ElectraPre(ChebaiBaseNet):
         **kwargs: Additional keyword arguments (passed to parent class).
 
     Attributes:
-        NAME (str): Name of the ElectraPre model.
         generator_config (ElectraConfig): Configuration for the generator model.
         generator (ElectraForMaskedLM): Generator model for masked language modeling.
         discriminator_config (ElectraConfig): Configuration for the discriminator model.
         discriminator (ElectraForPreTraining): Discriminator model for pre-training.
         replace_p (float): Probability of replacing tokens during training.
     """
-
-    NAME = "ElectraPre"
 
     def __init__(self, config: Dict[str, Any] = None, **kwargs: Any):
         super().__init__(config=config, **kwargs)
@@ -174,11 +171,7 @@ class Electra(ChebaiBaseNet):
         load_prefix (str, optional): Prefix to filter the state_dict keys from the pretrained checkpoint. Defaults to None.
         **kwargs: Additional keyword arguments.
 
-    Attributes:
-        NAME (str): Name of the Electra model.
     """
-
-    NAME = "Electra"
 
     def _process_batch(self, batch: Dict[str, Any], batch_idx: int) -> Dict[str, Any]:
         """
@@ -328,7 +321,7 @@ class Electra(ChebaiBaseNet):
             inp = self.electra.embeddings.forward(data["features"].int())
         except RuntimeError as e:
             print(f"RuntimeError at forward: {e}")
-            print(f'data[features]: {data["features"]}')
+            print(f"data[features]: {data['features']}")
             raise e
         inp = self.word_dropout(inp)
         electra = self.electra(inputs_embeds=inp, **kwargs)
@@ -340,8 +333,6 @@ class Electra(ChebaiBaseNet):
 
 
 class ElectraLegacy(ChebaiBaseNet):
-    NAME = "ElectraLeg"
-
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.config = ElectraConfig(**kwargs["config"], output_attentions=True)
@@ -374,8 +365,6 @@ class ElectraLegacy(ChebaiBaseNet):
 
 
 class ConeElectra(ChebaiBaseNet):
-    NAME = "ConeElectra"
-
     def _process_batch(self, batch, batch_idx):
         mask = pad_sequence(
             [torch.ones(l + 1, device=self.device) for l in batch.lens],

--- a/chebai/models/ffn.py
+++ b/chebai/models/ffn.py
@@ -9,15 +9,13 @@ from chebai.models import ChebaiBaseNet
 class FFN(ChebaiBaseNet):
     # Reference: https://github.com/bio-ontology-research-group/deepgo2/blob/main/deepgo/models.py#L121-L139
 
-    NAME = "FFN"
-
     def __init__(
         self,
         input_size: int,
         hidden_layers: List[int] = [
             1024,
         ],
-        **kwargs
+        **kwargs,
     ):
         super().__init__(**kwargs)
 

--- a/chebai/models/lstm.py
+++ b/chebai/models/lstm.py
@@ -10,8 +10,6 @@ logging.getLogger("pysmiles").setLevel(logging.CRITICAL)
 
 
 class ChemLSTM(ChebaiBaseNet):
-    NAME = "LSTM"
-
     def __init__(self, in_d, out_d, num_classes, **kwargs):
         super().__init__(num_classes, **kwargs)
         self.lstm = nn.LSTM(in_d, out_d, batch_first=True)

--- a/chebai/models/recursive.py
+++ b/chebai/models/recursive.py
@@ -11,8 +11,6 @@ logging.getLogger("pysmiles").setLevel(logging.CRITICAL)
 
 
 class Recursive(ChebaiBaseNet):
-    NAME = "REC"
-
     def __init__(self, in_d, out_d, num_classes, **kwargs):
         super().__init__(num_classes, **kwargs)
         mem_len = in_d


### PR DESCRIPTION


This PR updates the model registration logic to use Python's built-in `cls.__name__` instead of a custom `cls.NAME` attribute when checking and storing class references in `_MODEL_REGISTRY`.

#### 🔍 Reason for the change:

* Using `cls.__name__` is more robust and Pythonic—it ensures every class is uniquely identified by its actual class name without relying on the presence or consistency of a manually defined `NAME` attribute.
* Prevents potential issues where `cls.NAME` may be missing, misdefined, or inconsistent across subclasses.

This should make subclass registration safer and eliminate silent bugs due to missing or duplicate `NAME` attributes.
