### PR TITLE
Make training deterministic 

### DIFF
--- a/chebai/trainer/CustomTrainer.py
+++ b/chebai/trainer/CustomTrainer.py
@@ -25,7 +25,7 @@ class CustomTrainer(Trainer):
         """
         self.init_args = args
         self.init_kwargs = kwargs
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs, deterministic=True)
         # instantiation custom logger connector
         self._logger_connector.on_trainer_init(self.logger, 1)
         # log additional hyperparameters to wandb


### PR DESCRIPTION


Using `seed_everything(seed)` helps with reproducibility by setting seeds for Python's `random`, NumPy, and PyTorch (both CPU and CUDA), and it also sets:

1. `random.seed(seed)` — Python’s built-in random module.
2. `np.random.seed(seed)` — NumPy's random number generator.
3. `torch.manual_seed(seed)` — PyTorch’s RNG on CPU.
4. `torch.cuda.manual_seed(seed)` — PyTorch’s RNG on current GPU.
5. `torch.cuda.manual_seed_all(seed)` — For all GPUs.
6. `torch.backends.cudnn.deterministic = True` — Forces cuDNN to use deterministic algorithms.
7. `torch.backends.cudnn.benchmark = False` — Disables the autotuner that selects the fastest convolution algorithm (introduces randomness).

However, this **doesn't imply** that `Trainer(deterministic=True)` is set. The `deterministic` flag in the Trainer does more — it enforces deterministic algorithms during training and can catch known non-deterministic ops **(especially on GPU)**, which is useful for debugging reproducibility issues.

✅ **Recommendation:** Use both together for maximum reproducibility:

```python
seed_everything(42)
trainer = Trainer(deterministic=True, ...)
```
### Pytorch-lightning sets `seed_everything` to 0 by default, if no seed is provided but not the trainer's deterministic flag which is set to None by default.

Please check the below links: 

- https://lightning.ai/docs/pytorch/stable/common/trainer.html#reproducibility
- https://github.com/Lightning-AI/pytorch-lightning/discussions/11250

