### PR TITLE
fix import for XYBaseDataModule

### DIFF
--- a/chebai/cli.py
+++ b/chebai/cli.py
@@ -2,7 +2,7 @@ from typing import Dict, Set, Type
 
 from lightning.pytorch.cli import LightningArgumentParser, LightningCLI
 
-from chebai.preprocessing.datasets import XYBaseDataModule
+from chebai.preprocessing.datasets.base import XYBaseDataModule
 from chebai.trainer.CustomTrainer import CustomTrainer
 
 


### PR DESCRIPTION
For some reason, the import for the XYBaseDataModule was wrong. This is an easy fix, but it feels like this should not have happened in the first place.

@aditya0by0 Can you add a unit test that would catch this sort of error?