### PR TITLE
Fix data splits for pubchem

### DIFF
--- a/chebai/preprocessing/datasets/pubchem.py
+++ b/chebai/preprocessing/datasets/pubchem.py
@@ -154,9 +154,13 @@ class PubChem(XYBaseDataModule):
         print("Load data from file", filename)
         data = self._load_data_from_file(filename)
         print("Create splits")
-        train, test = train_test_split(data, train_size=self.train_split)
+        train, test = train_test_split(
+            data, train_size=1 - (self.validation_split + self.test_split)
+        )
         del data
-        test, val = train_test_split(test, train_size=self.train_split)
+        test, val = train_test_split(
+            test, train_size=self.test_split / (self.validation_split + self.test_split)
+        )
         torch.save(train, os.path.join(self.processed_dir, "train.pt"))
         torch.save(test, os.path.join(self.processed_dir, "test.pt"))
         torch.save(val, os.path.join(self.processed_dir, "validation.pt"))

--- a/chebai/preprocessing/datasets/pubchem.py
+++ b/chebai/preprocessing/datasets/pubchem.py
@@ -185,16 +185,14 @@ class PubChem(XYBaseDataModule):
 
     def _set_processed_data_props(self):
         """
-        Load processed data and extract metadata.
+        Self-supervised learning with PubChem does not use this metadata, therefore set them to zero.
 
         Sets:
-            - self._num_of_labels: Number of target labels in the dataset.
+            - self._num_of_labels: 0
             - self._feature_vector_size: 0.
         """
-        with open(os.path.join(self.processed_dir_main, "classes.txt")) as f:
-            classes = [f.strip() for f in f.readlines() if f.strip()]
 
-        self._num_of_labels = len(classes)
+        self._num_of_labels = 0
         self._feature_vector_size = 0
 
         print(f"Number of labels for loaded data: {self._num_of_labels}")

--- a/chebai/preprocessing/datasets/pubchem.py
+++ b/chebai/preprocessing/datasets/pubchem.py
@@ -191,7 +191,7 @@ class PubChem(XYBaseDataModule):
             - self._num_of_labels: Number of target labels in the dataset.
             - self._feature_vector_size: 0.
         """
-        with open(self.processed_dir_main, "classes.txt") as f:
+        with open(os.path.join(self.processed_dir_main, "classes.txt")) as f:
             classes = [f.strip() for f in f.readlines() if f.strip()]
 
         self._num_of_labels = len(classes)

--- a/chebai/preprocessing/datasets/pubchem.py
+++ b/chebai/preprocessing/datasets/pubchem.py
@@ -183,6 +183,23 @@ class PubChem(XYBaseDataModule):
         """
         return ["test.pt", "train.pt", "validation.pt"]
 
+    def _set_processed_data_props(self):
+        """
+        Load processed data and extract metadata.
+
+        Sets:
+            - self._num_of_labels: Number of target labels in the dataset.
+            - self._feature_vector_size: 0.
+        """
+        with open(self.processed_dir_main, "classes.txt") as f:
+            classes = [f.strip() for f in f.readlines() if f.strip()]
+
+        self._num_of_labels = len(classes)
+        self._feature_vector_size = 0
+
+        print(f"Number of labels for loaded data: {self._num_of_labels}")
+        print(f"Feature vector size: {self._feature_vector_size}")
+
     def _perform_data_preparation(self, *args, **kwargs):
         """
         Checks for raw data and downloads if necessary.


### PR DESCRIPTION
Pubchem dataset was still using `train_split`, while the superclass uses `validation_split` and `test_split`.

Also, the `_set_processed_data_props` method has been causing problems because it looks for a number of labels which does not exist for unlabeled data. As far as I know, this method is mainly used for logging, therefore i set the return values to 0