### PR TITLE
Fix PubChemBatched dataset

### DIFF
--- a/chebai/models/electra.py
+++ b/chebai/models/electra.py
@@ -63,10 +63,22 @@ class ElectraPre(ChebaiBaseNet):
         # cut off to max length of max_position_embeddings
         x = batch.x[:, : self.generator_config.max_position_embeddings]
 
+        model_kwargs = batch.additional_fields["model_kwargs"]
+        if "mask" in model_kwargs:
+            try:
+                model_kwargs["mask"] = model_kwargs["mask"][
+                    :, : self.generator_config.max_position_embeddings
+                ]
+            except Exception as e:
+                print(
+                    f"Failed to cut off mask {model_kwargs['mask'].shape} to max_position_embeddings: {e}"
+                )
+                raise e
+
         return dict(
             features=x,
             labels=self._process_labels_in_batch(batch),
-            model_kwargs=batch.additional_fields["model_kwargs"],
+            model_kwargs=model_kwargs,
             loss_kwargs=batch.additional_fields["loss_kwargs"],
             idents=batch.additional_fields["idents"],
         )

--- a/chebai/models/electra.py
+++ b/chebai/models/electra.py
@@ -48,6 +48,29 @@ class ElectraPre(ChebaiBaseNet):
         self.discriminator = ElectraForPreTraining(self.discriminator_config)
         self.replace_p = 0.1
 
+    def _process_batch(self, batch: Dict[str, Any], batch_idx: int) -> Dict[str, Any]:
+        """
+        Processes the batch data, cuts off x to max_position_embeddings
+
+        Args:
+            batch (XYData): The input batch of data.
+            batch_idx (int): The index of the current batch.
+
+        Returns:
+            Dict[str, Any]: Processed batch data.
+        """
+
+        # cut off to max length of max_position_embeddings
+        x = batch.x[:, : self.generator_config.max_position_embeddings]
+
+        return dict(
+            features=x,
+            labels=self._process_labels_in_batch(batch),
+            model_kwargs=batch.additional_fields["model_kwargs"],
+            loss_kwargs=batch.additional_fields["loss_kwargs"],
+            idents=batch.additional_fields["idents"],
+        )
+
     @property
     def as_pretrained(self) -> ElectraForPreTraining:
         """

--- a/chebai/models/electra.py
+++ b/chebai/models/electra.py
@@ -204,8 +204,13 @@ class Electra(ChebaiBaseNet):
             * CLS_TOKEN
         )
         model_kwargs["output_attentions"] = True
+
+        x = torch.cat((cls_tokens, batch.x), dim=1)
+        # cut off to max length of max_position_embeddings
+        x = x[:, : self.config.max_position_embeddings]
+
         return dict(
-            features=torch.cat((cls_tokens, batch.x), dim=1),
+            features=x,
             labels=batch.y,
             model_kwargs=model_kwargs,
             loss_kwargs=loss_kwargs,

--- a/chebai/preprocessing/datasets/pubchem.py
+++ b/chebai/preprocessing/datasets/pubchem.py
@@ -4,7 +4,7 @@ import random
 import shutil
 import tempfile
 from datetime import datetime
-from typing import Generator, List, Optional, Tuple, Type, Union
+from typing import Dict, Generator, List, Optional, Tuple, Type, Union
 
 import pandas as pd
 import requests
@@ -284,10 +284,10 @@ class PubChemBatched(PubChem):
             self.test_batch_size = 100_000
 
     @property
-    def processed_file_names_dict(self) -> List[str]:
+    def processed_file_names_dict(self) -> Dict[str, str]:
         """
         Returns:
-            List[str]: List of processed data file names.
+            Dict[str, str]: Dictionary of processed data file names.
         """
         train_samples = (
             self._n_samples
@@ -403,6 +403,29 @@ class PubChemBatched(PubChem):
             persistent_workers=True,
             **kwargs,
         )
+
+    def _get_data_splits(self) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+        """
+        The PubChemBatched dataset comes with pre-split data
+        """
+
+        train = self.load_processed_data_from_file(
+            self.processed_file_names_dict[
+                "train"
+                if "train" in self.processed_file_names_dict
+                else f"train_{self.curr_epoch}"
+            ]
+        )
+        train_df = pd.DataFrame(train)
+        val = self.load_processed_data_from_file(
+            self.processed_file_names_dict["validation"]
+        )
+        val_df = pd.DataFrame(val)
+        test = self.load_processed_data_from_file(
+            self.processed_file_names_dict["test"]
+        )
+        test_df = pd.DataFrame(test)
+        return train_df, val_df, test_df
 
 
 class LabeledUnlabeledMixed(XYBaseDataModule):

--- a/chebai/preprocessing/datasets/pubchem.py
+++ b/chebai/preprocessing/datasets/pubchem.py
@@ -4,7 +4,7 @@ import random
 import shutil
 import tempfile
 from datetime import datetime
-from typing import Dict, Generator, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, Generator, List, Optional, Tuple, Type, Union
 
 import pandas as pd
 import requests
@@ -404,28 +404,26 @@ class PubChemBatched(PubChem):
             **kwargs,
         )
 
-    def _get_data_splits(self) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    def load_processed_data(
+        self, kind: Optional[str] = None, filename: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
         """
-        The PubChemBatched dataset comes with pre-split data
+        Loads processed data from a specified dataset type or file. Loads data directly from file instead of
+        using the dynamic_splits_df property. This ensures that a new training batch is loaded for each epoch.
         """
+        if kind is None and filename is None:
+            raise ValueError(
+                "Either kind or filename is required to load the correct dataset, both are None"
+            )
 
-        train = self.load_processed_data_from_file(
-            self.processed_file_names_dict[
-                "train"
-                if "train" in self.processed_file_names_dict
-                else f"train_{self.curr_epoch}"
-            ]
-        )
-        train_df = pd.DataFrame(train)
-        val = self.load_processed_data_from_file(
-            self.processed_file_names_dict["validation"]
-        )
-        val_df = pd.DataFrame(val)
-        test = self.load_processed_data_from_file(
-            self.processed_file_names_dict["test"]
-        )
-        test_df = pd.DataFrame(test)
-        return train_df, val_df, test_df
+        # If both kind and filename are given, use filename
+        if kind is not None and filename is None:
+            return self.load_processed_data_from_file(
+                self.processed_file_names_dict[kind]
+            )
+
+        # If filename is provided
+        return self.load_processed_data_from_file(filename)
 
 
 class LabeledUnlabeledMixed(XYBaseDataModule):

--- a/configs/model/electra-for-pretraining.yml
+++ b/configs/model/electra-for-pretraining.yml
@@ -7,13 +7,13 @@ init_args:
     lr: 1e-3
   config:
     generator:
-      vocab_size: 4400
+      vocab_size: 600
       max_position_embeddings: 1800
       num_attention_heads: 8
       num_hidden_layers: 6
       type_vocab_size: 1
     discriminator:
-      vocab_size: 4400
+      vocab_size: 600
       max_position_embeddings: 1800
       num_attention_heads: 8
       num_hidden_layers: 6

--- a/configs/model/electra300.yml
+++ b/configs/model/electra300.yml
@@ -4,7 +4,7 @@ init_args:
   optimizer_kwargs:
     lr: 1e-3
   config:
-    vocab_size: 4400
+    vocab_size: 600
     max_position_embeddings: 301
     num_attention_heads: 8
     num_hidden_layers: 6


### PR DESCRIPTION
When changing the PubChem dataset to dynamic in #167, I forgot that the PubChemBatched dataset actually isn't that dynamic (i.e., has different files for train/val/test). To make things more complicated, the train set is split across multiple files. 

Therefore, we need to 
- [x] overwrite `load_processed_data` with the custom data loading scheme
- [x] create a splits.csv file and enable loading a dataset from this file