### PR TITLE
Rename 'val' to 'validation' in data splits

### DIFF
--- a/chebai/preprocessing/datasets/chebi.py
+++ b/chebai/preprocessing/datasets/chebi.py
@@ -393,7 +393,7 @@ class _ChEBIDataExtractor(_DynamicDataset, ABC):
             self.test_split,
             self.dynamic_data_split_seed,
         )
-        return splits["train"], splits["val"], splits["test"]
+        return splits["train"], splits["validation"], splits["test"]
 
     def _setup_pruned_test_set(
         self, df_test_chebi_version: pd.DataFrame

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dev = [
     "omegaconf",
     "deepsmiles",
     "torchmetrics",
-    "chebi-utils>=0.1.1",
+    "chebi-utils>=0.3",
 ]
 
 linters = [


### PR DESCRIPTION
chebi_utils changes its internal name from "val" to "validation"

- [x] update pyproject.toml to latest chebi_utils version once it is released