### PR TITLE
ChEBI IDs should always be strings

### DIFF
--- a/chebai/preprocessing/datasets/base.py
+++ b/chebai/preprocessing/datasets/base.py
@@ -1111,6 +1111,7 @@ class _DynamicDataset(XYBaseDataModule, ABC):
         filename = self.processed_file_names_dict["data"]
         data = self.load_processed_data_from_file(filename)
         df_data = pd.DataFrame(data)
+        df_data["ident"] = df_data["ident"].astype(str)
 
         if self.apply_id_filter:
             print(f"Applying ID filter from {self.apply_id_filter}...")


### PR DESCRIPTION
ChEBI IDs should be treated as strings. However, pandas sees this differently and automatically assigns them to the integer datatype. This leads to issues down the line, e.g., when filtering into train/val/test:

        self._dynamic_df_train = df_data[df_data["ident"].isin(train_ids)]
        self._dynamic_df_val = df_data[df_data["ident"].isin(validation_ids)]
        self._dynamic_df_test = df_data[df_data["ident"].isin(test_ids)]

`train_ids`, `validation_ids` and `test_ids` are lists of strings, so the assignment fails if `df_data` contains integers.